### PR TITLE
Add cloud_run_services

### DIFF
--- a/terraform/dev/europe-west1/services/cloud_run_services/common.tfvars
+++ b/terraform/dev/europe-west1/services/cloud_run_services/common.tfvars
@@ -1,0 +1,2 @@
+document_client_image = "eu.gcr.io/document-automation-dev/document-client:latest"
+classify_backend_url = "europe-west1-document-automation-dev.cloudfunctions.net/classify"

--- a/terraform/dev/europe-west1/services/cloud_run_services/terragrunt.hcl
+++ b/terraform/dev/europe-west1/services/cloud_run_services/terragrunt.hcl
@@ -1,0 +1,14 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "github.com/fuzzylabs/document-automation-terraform-modules//cloud_run_services"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependencies {
+  paths = ["../cloud_functions"]
+}


### PR DESCRIPTION
Depends upon https://github.com/fuzzylabs/document-automation-terraform-modules/pull/2

Note: The value for `classify_backend_url` should probably be looked up from a data source instead of passed in as a hard coded value.